### PR TITLE
Remove unicode characters to allow latin-1

### DIFF
--- a/netbox_netprod_importer/__main__.py
+++ b/netbox_netprod_importer/__main__.py
@@ -106,7 +106,7 @@ def parse_args():
             logging.getLogger().setLevel(numeric_level)
 
         args.creds = _get_creds(args)
-        print("Initializing importers…")
+        print("Initializing importers...")
         if args.devices:
             args.importers = parse_devices_yaml_def(
                 args.devices, args.creds
@@ -128,7 +128,7 @@ def inventory(parsed_args):
     interconnect(parsed_args)
 
 def import_data(parsed_args):
-    print("Fetching and pushing data…")
+    print("Fetching and pushing data...")
     for host, props in _multithreaded_devices_polling(
             importers=parsed_args.importers,
             threads=parsed_args.threads,


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/netbox/venv/bin/netbox-netprod-importer", line 11, in <module>
    sys.exit(parse_args())
  File "/opt/netbox/venv/lib/python3.6/site-packages/netbox_netprod_importer/__main__.py", line 109, in parse_args
    print("Initializing importers\u2026")
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2026' in position 22: ordinal not in range(256)
```