### PR TITLE
add functions to call lib through python

### DIFF
--- a/netbox_netprod_importer/__init__.py
+++ b/netbox_netprod_importer/__init__.py
@@ -2,3 +2,4 @@ __author__ = """Scaleway"""
 __email__ = "contact@scaleway.com"
 __version__ = "0.3.3"
 __appname__ = "netbox-netprod-importer"
+from .__main__ import *

--- a/netbox_netprod_importer/__main__.py
+++ b/netbox_netprod_importer/__main__.py
@@ -10,8 +10,8 @@ from netboxapi import NetboxAPI
 from tqdm import tqdm
 
 from . import __appname__, __version__
-from netbox_netprod_importer.config import get_config, load_config
-from netbox_netprod_importer.devices_list import parse_devices_yaml_def
+from netbox_netprod_importer.config import get_config, load_config, load_config_from_args
+from netbox_netprod_importer.devices_list import parse_devices_yaml_def, parse_devices_dict
 from netbox_netprod_importer.devices_list import parse_filter_yaml_def
 from netbox_netprod_importer.push import (
     NetboxDevicePropsPusher, NetboxInterconnectionsPusher
@@ -122,6 +122,24 @@ def parse_args():
     else:
         arg_parser.print_help()
         sys.exit(1)
+
+def init_importer(device_dict,user,password,verbose=None):
+    # Create a parser so we can fill it exactly like the CLI one
+    parser = argparse.ArgumentParser()
+    arg_parser = parser
+    args = arg_parser.parse_args()
+
+    # Add the config from the args
+    args.creds = (user,password)
+    args.ask_password = False
+    args.filter=None
+    args.overwrite=False
+    args.threads=10
+    args.importers = parse_devices_dict(device_dict,args.creds)
+    args.verbose = verbose
+
+    return args
+
 
 def inventory(parsed_args):
     import_data(parsed_args)

--- a/netbox_netprod_importer/config.py
+++ b/netbox_netprod_importer/config.py
@@ -69,5 +69,23 @@ def get_config(custom_path=None):
         raise FileNotFoundError
 
 
+def load_config_from_args(verbose=None, disable_ssl_warnings=True, netbox_url="", netbox_token="", remove_domains=['foo.tld'], loglevel=None):
+    if disable_ssl_warnings == False:
+        urllib3.disable_warnings()
+    if loglevel is not None:
+        numeric_level = getattr(logging, loglevel.upper())
+        if not isinstance(numeric_level, int):
+            raise ValueError('Invalid log level: %s' % loglevel)
+        else:
+            numeric_level = logging.ERROR
+            logging.basicConfig(level=numeric_level,
+                                format="%(levelname)s: %(name)s: %(message)s")
+     
+    return {'verbose': verbose, 'disable_ssl_warnings': disable_ssl_warnings,
+            'netbox': {'url': netbox_url, 'token': netbox_token, 'remove_domains': remove_domains}}
+
+
+
+
 def load_config(custom_path=None):
     get_config(custom_path)

--- a/netbox_netprod_importer/devices_list.py
+++ b/netbox_netprod_importer/devices_list.py
@@ -31,6 +31,25 @@ def parse_devices_yaml_def(devices_yaml, creds=None):
                 )
     return devices
 
+def parse_devices_dict(devices_dict,creds=None):
+    devices = {}
+    for hostname, props in devices_dict.items():
+        try:
+            devices[hostname] = DeviceImporter(
+                props.get("target") or hostname,
+                napalm_driver_name=props["driver"],
+                napalm_optional_args=props.get("optional_args"),
+                creds=creds,
+                discovery_protocol=props.get("discovery_protocol")
+            )
+        except Exception as e:
+            logger.error(
+                "Cannot connect to device %s: %s", hostname, e
+            )
+    return devices
+
+
+
 
 def parse_filter_yaml_def(filter_yaml, creds=None):
     netbox_api = NetboxAPI(**get_config()["netbox"])


### PR DESCRIPTION
Hi, I think it would be great to be able to call the lib directly from python code, so it would be possible to have a programmatic approach to importing devices.

I've added a few functions to start, for now we can import / interconnect devices using a configuration generated by a script that would call the netbox-netprod-importer lib, but the config of the lib (url of netbox etc) still needs to be a file loaded by netbox_netprod_importer.config.get_config(). I don't know what would be the best approach regarding this.

As an example, one could use the lib like so : 

```python
import netbox_netprod_importer

devices = {'SWITCH1': {'driver': 'ios', 'target': '192.168.1.1', 'discovery_protocol': 'cpd'}, 'SWITCH2': {'driver': 'ios', 'target': '192.168.1.2', 'discovery_protocol': 'cpd'}}

parsed_args = netbox_netprod_importer.init_importer(devices,"user","password")
netbox_netprod_importer.load_config(custom_path="config.yml")
netbox_netprod_importer.import_data(parsed_args)
```

It's clearly not ready to be merged, but maybe you would have ideas on how to implement this as you know better the lib than I do.

Thx,
